### PR TITLE
added client id support for kafka_franz input and output

### DIFF
--- a/internal/impl/kafka/input_kafka_franz.go
+++ b/internal/impl/kafka/input_kafka_franz.go
@@ -73,7 +73,7 @@ Finally, it's also possible to specify an explicit offset to consume from by add
 			Advanced()).
 		Field(service.NewStringField("rack_id").
 			Description("A rack identifier for this client.").
-			Optional().
+			Default("").
 			Advanced()).
 		Field(service.NewIntField("checkpoint_limit").
 			Description("Determines how many messages of the same partition can be processed in parallel before applying back pressure. When a message of a given offset is delivered to the output the offset is only allowed to be committed when all messages of prior offsets have also been delivered, this ensures at-least-once delivery guarantees. However, this mechanism also increases the likelihood of duplicates in the event of crashes or server faults, reducing the checkpoint limit will mitigate this.").

--- a/internal/impl/kafka/input_kafka_franz.go
+++ b/internal/impl/kafka/input_kafka_franz.go
@@ -205,11 +205,11 @@ func newFranzKafkaReaderFromConfig(conf *service.ParsedConfig, res *service.Reso
 		return nil, err
 	}
 
-	if f.rackID, err = conf.FieldString("rack_id"); err != nil {
+	if f.clientID, err = conf.FieldString("client_id"); err != nil {
 		return nil, err
 	}
 
-	if f.clientID, err = conf.FieldString("client_id"); err != nil {
+	if f.rackID, err = conf.FieldString("rack_id"); err != nil {
 		return nil, err
 	}
 

--- a/internal/impl/kafka/output_kafka_franz.go
+++ b/internal/impl/kafka/output_kafka_franz.go
@@ -54,7 +54,7 @@ This output often out-performs the traditional ` + "`kafka`" + ` output as well 
 			Advanced()).
 		Field(service.NewStringField("rack_id").
 			Description("A rack identifier for this client.").
-			Optional().
+			Default("").
 			Advanced()).
 		Field(service.NewMetadataFilterField("metadata").
 			Description("Determine which (if any) metadata values should be added to messages as headers.").

--- a/website/docs/components/inputs/kafka_franz.md
+++ b/website/docs/components/inputs/kafka_franz.md
@@ -52,6 +52,8 @@ input:
     topics: []
     regexp_topics: false
     consumer_group: ""
+    client_id: benthos
+    rack_id: ""
     checkpoint_limit: 1024
     commit_period: 5s
     start_from_oldest: true
@@ -167,6 +169,22 @@ An optional consumer group to consume as. When specified the partitions of speci
 
 
 Type: `string`  
+
+### `client_id`
+
+An identifier for the client connection.
+
+
+Type: `string`  
+Default: `"benthos"`  
+
+### `rack_id`
+
+A rack identifier for this client.
+
+
+Type: `string`  
+Default: `""`  
 
 ### `checkpoint_limit`
 

--- a/website/docs/components/outputs/kafka_franz.md
+++ b/website/docs/components/outputs/kafka_franz.md
@@ -62,6 +62,8 @@ output:
     key: ""
     partitioner: ""
     partition: ""
+    client_id: benthos
+    rack_id: ""
     metadata:
       include_prefixes: []
       include_patterns: []
@@ -160,6 +162,22 @@ Type: `string`
 
 partition: ${! meta("partition") }
 ```
+
+### `client_id`
+
+An identifier for the client connection.
+
+
+Type: `string`  
+Default: `"benthos"`  
+
+### `rack_id`
+
+A rack identifier for this client.
+
+
+Type: `string`  
+Default: `""`  
 
 ### `metadata`
 


### PR DESCRIPTION
We are able to customize the client id

<img width="1218" alt="image" src="https://github.com/timeplus-io/benthos/assets/3864601/f7d6069a-0fdf-4844-a4ba-11706bec14cf">
