### PR TITLE
update websocket

### DIFF
--- a/internal/impl/io/input_websocket.go
+++ b/internal/impl/io/input_websocket.go
@@ -200,12 +200,9 @@ func (w *websocketReader) Connect(ctx context.Context) error {
 				if len(msg) == 0 {
 					continue
 				}
-				// TODO: will need remove such log later cause it may contain sensitive info
-				w.log.Infof("sending open message %s to server", string(msg))
 				if err := client.WriteMessage(openMsgType, msg); err != nil {
 					return err
 				}
-				// time.Sleep(3 * time.Second) // TODO : confirm the hand shake here?
 			}
 		}
 	}

--- a/internal/impl/io/input_websocket.go
+++ b/internal/impl/io/input_websocket.go
@@ -44,7 +44,7 @@ func websocketInputSpec() *service.ConfigSpec {
 				Description("An optional message to send to the server upon connection.").
 				Advanced().Optional(),
 			service.NewStringListField("open_messages").
-				Description("An optional messages to send to the server upon connection.").
+				Description("An optional list of messages to send to the server after open messages if specified.").
 				Advanced().Optional(),
 			service.NewStringAnnotatedEnumField("open_message_type", map[string]string{
 				string(wsOpenMsgTypeBinary): "Binary data open_message.",


### PR DESCRIPTION
support multple open messages by multiple line

here is a test pipeline

```
input:
  label: alpaca
  websocket:
    url: wss://stream.data.alpaca.markets/v2/iex
    open_messages: 
      - '{"action": "auth", "key":"xxx", "secret":"xxx"}'
      - '{"action":"subscribe","trades":["AAPL"],"quotes":["AMD","CLDR"],"bars":["*"]}'
    open_message_type: text

output:
  stdout: {}
```